### PR TITLE
0.87.1-clock_app-bug-fix.c

### DIFF
--- a/applications/plugins/clock/clock_app.c
+++ b/applications/plugins/clock/clock_app.c
@@ -56,7 +56,7 @@ static void clock_render_callback(Canvas* canvas, void* ctx) {
             31,
             AlignLeft,
             AlignCenter,
-            (data->datetime.hour > 12) ? "PM" : "AM");
+            (data->datetime.hour > 11) ? "PM" : "AM");
     }
 
     canvas_set_font(canvas, FontSecondary);


### PR DESCRIPTION
# What's new
fixed the issue where the clock switches from am to pm at 1pm and now switches over at 12
- [ Describe changes here ]
changed the greater than check from 12 to 11
# Verification 

- [ Describe how to verify changes ]
simply set your clock back to 11:55am and wait until it switches to 12 to see results

patch has been uploaded to a flipper zero and is working as intended
before: https://cdn.discordapp.com/attachments/746304505879986267/1079892843147038770/IMG_8832.jpg
after: https://cdn.discordapp.com/attachments/746304505879986267/1079892843524534302/IMG_8833.jpg
# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
